### PR TITLE
No longer overwrite locale tag inside labels (fixes #9)

### DIFF
--- a/relabel/resources/js/Relabel.js
+++ b/relabel/resources/js/Relabel.js
@@ -190,7 +190,11 @@
 
 					if(label.name)
 					{
-						$label.text(Craft.t(label.name));
+						var $labelText = $label.contents().filter(function () {
+							return this.nodeType == 3;
+						}).first();
+
+						$labelText.replaceWith(document.createTextNode(Craft.t(label.name)));
 					}
 
 					if(label.instructions)


### PR DESCRIPTION
Relabel would inadvertently overwrite the locale label for translatable fields. This fix takes care to only overwrite the label text and not any child elements, thereby preserving the locale label.