### PR TITLE
Convert instructions from varchar(255) to text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "spicyweb/craft-fieldlabels",
   "description": "Override Craft CMS field labels and instructions in the field layout designer",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "type": "craft-plugin",
   "keywords": [
     "craftcms",
@@ -30,7 +30,7 @@
   "extra": {
     "handle": "fieldlabels",
     "name": "Field Labels",
-    "schemaVersion": "1.0.0",
+    "schemaVersion": "1.1.0",
     "class": "spicyweb\\fieldlabels\\Plugin",
     "changelogUrl": "https://github.com/spicywebau/craft-fieldlabels/blob/master/CHANGELOG.md",
     "downloadUrl": "https://github.com/spicywebau/craft-fieldlabels/archive/master.zip"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -38,7 +38,7 @@ class Plugin extends BasePlugin
 	/**
 	 * @inheritdoc
 	 */
-	public $schemaVersion = '1.0.0';
+	public $schemaVersion = '1.1.0';
 
 	/**
 	 * @var array

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -31,7 +31,7 @@ class Install extends Migration
                 'fieldId' => $this->integer()->notNull(),
                 'fieldLayoutId' => $this->integer()->notNull(),
                 'name' => $this->string()->null(),
-                'instructions' => $this->string()->null(),
+                'instructions' => $this->text()->null(),
                 'dateCreated' => $this->dateTime()->notNull(),
                 'dateUpdated' => $this->dateTime()->notNull(),
                 'uid' => $this->uid(),

--- a/src/migrations/m190509_031301_instructions_varchar_to_text.php
+++ b/src/migrations/m190509_031301_instructions_varchar_to_text.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace spicyweb\fieldlabels\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m190509_031301_instructions_varchar_to_text migration.
+ *
+ * @package spicyweb\fieldlabels\migrations
+ * @author Spicy Web <craft@spicyweb.com.au>
+ * @since 1.1.0
+ */
+class m190509_031301_instructions_varchar_to_text extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->alterColumn('{{%fieldlabels}}', 'instructions', 'text');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m190509_031301_instructions_varchar_to_text cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
Craft stores its field instructions in the DB as `text`, so Field Labels' instructions should match.  Fixes #27.