### PR TITLE
Apply label names to error messages

### DIFF
--- a/src/resources/js/FieldLabels.js
+++ b/src/resources/js/FieldLabels.js
@@ -237,13 +237,23 @@
 					{
 						var $translatable = $label.children('[data-icon="language"]');
 						var isTranslatable = $translatable.length > 0;
+						var originalName = $label.text().trim();
+						var translatedName = Craft.t('fieldlabels', label.name);
 
-						$label.text(Craft.t('fieldlabels', label.name) + (isTranslatable ? ' ' : ''));
+						$label.text(translatedName + (isTranslatable ? ' ' : ''));
 
 						if(isTranslatable)
 						{
 							$label.append($translatable);
 						}
+
+						// Apply the label name to any errors
+						$field.children('.errors').children('li').each(function() {
+							var $error = $(this);
+							var newText = $error.text().replace(originalName, translatedName);
+
+							$error.text(newText);
+						});
 					}
 
 					if(label.instructions)


### PR DESCRIPTION
Applies field labels' names to associated error messages.  This applies to element edit pages and quick post widgets.  For quick post widgets, Field Labels itself would not apply label names to error messages for plugin-provided fields that have their own field layouts (e.g. Neo), but would trigger a jQuery event to allow such plugins to add support for this.

Resolves #29.