### PR TITLE
Fix labels not being deleted when name/instructions removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Field Labels supports overriding the names and instructions on any custom fields
 
 ## Requirements
 
-Field Labels requires Craft CMS 3.1.20 or later.  For Relabel for Craft 2, see the [`craft-2`](https://github.com/spicywebau/craft-fieldlabels/tree/craft-2) branch.
+Field Labels requires Craft CMS 3.1.24 or later.  For Relabel for Craft 2, see the [`craft-2`](https://github.com/spicywebau/craft-fieldlabels/tree/craft-2) branch.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "issues": "https://github.com/spicywebau/craft-fieldlabels/issues"
   },
   "require": {
-    "craftcms/cms": "^3.1.20"
+    "craftcms/cms": "^3.1.24"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This would ensure that, when saving a field layout, any labels associated with that layout's unlabelled fields (i.e. labels that the user removed in the field layout designer) are deleted from the DB and project.yaml.

Note that this PR makes use of Craft's recently-added `craft\services\Fields::getFieldIdsByLayoutId()` method to help determine the unlabelled fields, so this would bump Field Labels' minimum Craft version requirement to 3.1.24.

Fixes part two of issue #30.