### PR TITLE
Ensure $label exists when triggering afterSaveLabel event

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -257,6 +257,17 @@ class Service extends Component
 
             // Trigger an `afterSaveLabel` event
             if ($this->hasEventHandlers('afterSaveLabel')) {
+                $label = new FieldLabelModel([
+                    'id' => $record->id,
+                    'fieldId' => $record->fieldId,
+                    'fieldLayoutId' => $record->fieldLayoutId,
+                    'name' => $record->name,
+                    'instructions' => $record->instructions,
+                    'hideName' => $record->hideName,
+                    'hideInstructions' => $record->hideInstructions,
+                    'uid' => $record->uid,
+                ]);
+
                 $this->trigger('afterSaveLabel', new FieldLabelsEvent([
                     'label'      => $label,
                     'isNewLabel' => $isNew,


### PR DESCRIPTION
The `afterSaveLabel` event is supposed to send a `FieldLabelModel` `$label`, but `$label` was not set, causing an error.

Fixes #37.