### PR TITLE
Add ability to save labels for multiple field layouts in all cases; Verbb Wishlist support; Fix IE JS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Field Labels supports overriding the names and instructions on any custom fields
 - Craft Commerce product types, variants, orders and subscriptions
 - [Neo](https://github.com/spicywebau/craft-neo) fields
 - [Solspace Calendar](https://github.com/solspace/craft3-calendar) events
+- [Verbb Wishlist](https://github.com/verbb/wishlist) list types and items
 - [Verbb Events](https://github.com/verbb/events)
 - [Verbb Gift Voucher](https://github.com/verbb/gift-voucher)
 

--- a/src/resources/js/Editor.js
+++ b/src/resources/js/Editor.js
@@ -10,6 +10,7 @@
 	 */
 	var Editor = Garnish.Base.extend({
 
+		editorId: null,
 		fld: null,
 		labels: null,
 
@@ -28,18 +29,21 @@
 			this.fld = fld;
 			this.fld.on('fieldLabelsOptionSelected', $.proxy(this.openModal, this));
 
+			this.editorId = Math.max($('.fieldlayoutform').index(this.fld.$container), 0);
+
 			this.$form = this.fld.$container.closest('form');
 
 			this.labels = {};
 
 			var fieldLayoutId = FieldLabels.getFieldLayoutId(this.$form);
 
-			if(Array.isArray(fieldLayoutId))
+			if(typeof fieldLayoutId === 'object')
 			{
-				// Commerce!
-				var i = this.fld.$container.attr('id').split('-')[0] !== 'variant' ? 0 : 1;
-				this.namespace = 'fieldlabels-commerce[' + fieldLayoutId[i] + ']';
-				this.applyLabels(fieldLayoutId[i]);
+				// Commerce, Wishlist, could be reused for similar cases
+				var fldId = this.fld.$container.prop('id');
+				var item = fldId === 'fieldlayoutform' ? 'default' : fldId.split('-layout-')[0];
+
+				this.applyLabels(fieldLayoutId[item]);
 			}
 			else if(fieldLayoutId !== false)
 			{
@@ -91,10 +95,10 @@
 			var $container = this.fld.$container;
 			var $field = $container.find('.fld-field[data-id="' + fieldId + '"]');
 
-			var nameField = this.namespace + '[' + fieldId + '][name]';
-			var instructField = this.namespace + '[' + fieldId + '][instructions]';
-			var hideNameField = this.namespace + '[' + fieldId + '][hideName]';
-			var hideInstructField = this.namespace + '[' + fieldId + '][hideInstructions]';
+			var nameField = this.namespace + '[' + this.editorId + '][' + fieldId + '][name]';
+			var instructField = this.namespace + '[' + this.editorId + '][' + fieldId + '][instructions]';
+			var hideNameField = this.namespace + '[' + this.editorId + '][' + fieldId + '][hideName]';
+			var hideInstructField = this.namespace + '[' + this.editorId + '][' + fieldId + '][hideInstructions]';
 
 			$field.children('input[name="' + nameField + '"]').remove();
 			$field.children('input[name="' + instructField + '"]').remove();

--- a/src/resources/js/Editor.js
+++ b/src/resources/js/Editor.js
@@ -86,7 +86,7 @@
 			);
 		},
 
-		setFormData: function(fieldId, name, instruct, hideName = false, hideInstruct = false)
+		setFormData: function(fieldId, name, instruct, hideName, hideInstruct)
 		{
 			var $container = this.fld.$container;
 			var $field = $container.find('.fld-field[data-id="' + fieldId + '"]');

--- a/src/resources/js/EditorModal.js
+++ b/src/resources/js/EditorModal.js
@@ -114,7 +114,7 @@
 			this.$shade.remove();
 		},
 
-		show: function(name, instruct, hideName = false, hideInstruct = false)
+		show: function(name, instruct, hideName, hideInstruct)
 		{
 			if(name)         this.$nameField.val(name);
 			if(instruct)     this.$instructField.val(instruct);

--- a/src/resources/js/FieldLabels.js
+++ b/src/resources/js/FieldLabels.js
@@ -42,6 +42,11 @@
 			// Verbb Gift Voucher
 			GIFT_VOUCHER:                 'giftVoucher',
 			GIFT_VOUCHER_TYPE:            'giftVoucherType',
+			
+			// Verbb Wishlist
+			WISHLIST_LIST:                'wishlistList',
+			WISHLIST_LIST_ITEM:           'wishlistListItems',
+			WISHLIST_LIST_TYPE:           'wishlistListTypes',
 
 			// These objects will be populated in the Plugin.php file
 			fields:  null,
@@ -398,6 +403,11 @@
 							// Verbb Gift Voucher actions
 							case 'gift-voucher/vouchers/save': return this.GIFT_VOUCHER;
 							case 'gift-voucher/voucher-types/save': return this.GIFT_VOUCHER_TYPE;
+
+							// Verbb Wishlist actions
+							case 'wishlist/lists/save-list': return this.WISHLIST_LIST;
+							case 'wishlist/items/save-item': return this.WISHLIST_LIST_ITEM;
+							case 'wishlist/list-types/save-list-type': return this.WISHLIST_LIST_TYPE;
 						}
 					}
 				}
@@ -456,6 +466,9 @@
 					case this.EVENTS_TICKET_TYPE: selector = 'input[name="ticketTypeId"]'; break;
 					case this.GIFT_VOUCHER: selector = 'input[name="typeId"]'; break;
 					case this.GIFT_VOUCHER_TYPE: selector = 'input[name="voucherTypeId"]'; break;
+					case this.WISHLIST_LIST: selector = 'input[name="typeId"]'; break;
+					case this.WISHLIST_LIST_ITEM: selector = 'input[name="itemId"]'; break;
+					case this.WISHLIST_LIST_TYPE: selector = 'input[name="listTypeId"]'; break;
 				}
 
 				var $input = $form.find(selector);
@@ -508,6 +521,14 @@
 						case this.EVENTS_TICKET_TYPE: context = this.EVENTS_TICKET_TYPE; break;
 						case this.GIFT_VOUCHER:
 						case this.GIFT_VOUCHER_TYPE: context = this.GIFT_VOUCHER_TYPE; break;
+						case this.WISHLIST_LIST:
+						case this.WISHLIST_LIST_TYPE: context = this.WISHLIST_LIST_TYPE; break;
+						case this.WISHLIST_LIST_ITEM:
+						{
+							// Get the list ID from the breadcrumbs
+							var listId = $('#crumbs a').last().prop('href').split('/').pop();
+							return this.layouts[this.WISHLIST_LIST_ITEM][listId];
+						}
 					}
 
 					return this.layouts[context][contextId];

--- a/src/resources/js/FieldLabels.js
+++ b/src/resources/js/FieldLabels.js
@@ -206,11 +206,16 @@
 					}
 				}
 
-				if(Array.isArray(fieldLayoutId))
+				if(typeof fieldLayoutId === 'object')
 				{
-					// This is a Commerce product type, we need to apply the variant labels too
-					this.applyLabels(element, fieldLayoutId[1], 'variants-');
-					fieldLayoutId = fieldLayoutId[0];
+					// Commerce, Wishlist, could be reused for similar cases
+					for(var type in fieldLayoutId)
+					{
+						var namespace = type !== 'default' ? type + 's-' : null;
+						this.applyLabels(element, fieldLayoutId[type], namespace);
+					}
+
+					return;
 				}
 
 				var labels = this.getLabelsOnFieldLayout(fieldLayoutId);
@@ -495,14 +500,7 @@
 						case this.TAG:
 						case this.TAG_GROUP:      context = this.TAG_GROUP; break;
 						case this.COMMERCE_PRODUCT:
-						case this.COMMERCE_PRODUCT_TYPE:
-						{
-							context = this.COMMERCE_PRODUCT_TYPE;
-							return [
-								this.layouts[context][contextId]['productType'] | 0,
-								this.layouts[context][contextId]['variant'] | 0,
-							];
-						}
+						case this.COMMERCE_PRODUCT_TYPE: context = this.COMMERCE_PRODUCT_TYPE; break;
 						case this.CALENDAR:
 						case this.CALENDAR_EVENT: context = this.CALENDAR; break;
 						case this.EVENTS_EVENT:
@@ -512,7 +510,7 @@
 						case this.GIFT_VOUCHER_TYPE: context = this.GIFT_VOUCHER_TYPE; break;
 					}
 
-					return this.layouts[context][contextId] | 0;
+					return this.layouts[context][contextId];
 				} else {
 					switch(context)
 					{


### PR DESCRIPTION
Changes the way Field Labels formats its POST data; removing the Commerce-specific case in `spicyweb\fieldlabels\Plugin::_bindEvent()` of handling two field layouts for product types / variants and just making Field Labels send its data segmented by field layout in all cases.  This then allows for Verbb Wishlist support without having to provide another specific case in `_bindEvent()` for its similar list types / items, and should handle any other similar cases with other plugins that Field Labels might support in the future (provided that Field Labels is updated in the other relevant areas to support the plugins, of course).

Due to this update changing how Field Labels formats its POST data, it would also require a small update to Neo to maintain its compatibility with Field Labels.  See spicywebau/craft-neo#244.