### PR TITLE
add handling for localized create buttons

### DIFF
--- a/src/resources/js/FieldLabels.js
+++ b/src/resources/js/FieldLabels.js
@@ -369,6 +369,12 @@
 
 					var action = $action !== null ? $action.val() : false;
 
+					// handle localized create buttons
+					if (Craft.translations && Craft.translations.app && action === Craft.translations.app.Create)
+					{
+						action = 'Create';
+					}
+
 					if(action)
 					{
 						switch(action)


### PR DESCRIPTION
This fixes the re-labeling for localized user interfaces.
See https://github.com/spicywebau/craft-fieldlabels/issues/47#issuecomment-602470931