### PR TITLE
If there's a draftEditor return early

### DIFF
--- a/src/resources/js/FieldLabels.js
+++ b/src/resources/js/FieldLabels.js
@@ -345,6 +345,15 @@
 
                 var elementEditor = $form.data('elementEditor');
 
+                if(window.draftEditor) {
+                    switch(window.draftEditor.settings.elementType)
+                    {
+                        // TODO All other cases
+                        case 'craft\\elements\\Entry':
+                            return this.ENTRY;
+                    }
+                }
+                
                 if(elementEditor)
                 {
                     switch(elementEditor.settings.elementType)


### PR DESCRIPTION
Related to #51

There's a case where the user can create a draft but not publish. In these cases there's no button to find.

This PR uses the global window.draftEditor to test to see if the `elementType` is an entry which also shortcuts a lot of the existing code (which I've left for backwards compatibility).

This has only been tested on Craft 3.5.beta 2 for the use case above.