### PR TITLE
Ignore labels that belong to deleted field layouts

### DIFF
--- a/src/migrations/m200726_085655_craft_3_5_field_layout_transition.php
+++ b/src/migrations/m200726_085655_craft_3_5_field_layout_transition.php
@@ -33,7 +33,14 @@ class m200726_085655_craft_3_5_field_layout_transition extends Migration
         // Re-index the labels by layout/field UIDs, so we can easily look them up when updating the layouts
         foreach ($oldLabels as $label) {
             if (!isset($layouts[$label->fieldLayoutId])) {
-                $layouts[$label->fieldLayoutId] = $fieldsService->getLayoutById($label->fieldLayoutId);
+                $layout = $fieldsService->getLayoutById($label->fieldLayoutId);
+
+                // skip over labels belonging to deleted layouts
+                if (null === $layout) {
+                    continue;
+                }
+
+                $layouts[$label->fieldLayoutId] = $layout;
             }
 
             $layoutUid = $layouts[$label->fieldLayoutId]->uid;


### PR DESCRIPTION
We encountered an issue where the migration would fail because `$fieldsService->getLayoutById()` would return `null` for a layout where `dateDeleted` was set.

By skipping the label processing here during the check for the layout details we also make sure that the empty layout does not get processed later in the method where it tries to write directly to the database.

This should still perform OK as the Fields service caches layout results internally.